### PR TITLE
feat: simplify home screen

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,8 +9,8 @@ module.exports = {
     return `https://pinokiocomputer.github.io/home/item?uri=${gitRemote}&display=profile`
   },
   site: "https://pinokiocomputer.github.io/home",
-  discover_dark: "https://pinokiocomputer.github.io/home/app?theme=dark",
-  discover_light: "https://pinokiocomputer.github.io/home/app",
+  discover_dark: "/discover?theme=dark",
+  discover_light: "/discover?theme=light",
   portal: "https://pinokiocomputer.github.io/home/portal",
   docs: "https://pinokiocomputer.github.io/program.pinokio.computer",
   install: "https://pinokiocomputer.github.io/program.pinokio.computer/#/?id=install",

--- a/full.js
+++ b/full.js
@@ -5,6 +5,7 @@ const path = require("path")
 const Pinokiod = require("pinokiod")
 const os = require('os')
 const Updater = require('./updater')
+const axios = require('axios')
 const is_mac = process.platform.startsWith("darwin")
 const platform = os.platform()
 var mainWindow;
@@ -579,6 +580,18 @@ document.querySelector("form").addEventListener("submit", (e) => {
           await session.defaultSession.clearStorageData()
           console.log("cleared")
         }
+      }
+    })
+    pinokiod.app.get('/discover', async (req, res) => {
+      try {
+        const theme = req.query.theme || 'dark'
+        const url = `https://pinokio.co/app?theme=${theme}`
+        let html = (await axios.get(url)).data
+        html = html.replace(/<aside[\s\S]*?<\/aside>/, '')
+        html = html.replace(/<div class=\"community\">[\s\S]*?<\/div>/, '')
+        res.set('Content-Type', 'text/html').send(html)
+      } catch (e) {
+        res.status(500).send('Failed to load page')
       }
     })
     PORT = pinokiod.port

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Pinokio",
   "private": true,
-  "version": "3.41.0",
+  "version": "3.41.1",
   "homepage": "https://pinokio.co",
   "description": "pinokio",
   "main": "main.js",
@@ -119,7 +119,8 @@
     "electron-store": "^8.1.0",
     "electron-updater": "^6.6.2",
     "electron-window-state": "^5.0.3",
-    "pinokiod": "^3.41.0"
+    "pinokiod": "^3.41.0",
+    "axios": "^1.4.0"
   },
   "devDependencies": {
     "@electron/rebuild": "3.2.10",


### PR DESCRIPTION
## Summary
- remove News column and verified scripts notice by serving a sanitized discover page
- bump app version to 3.41.1

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68bf9e123b6083328a885fef241357e9