### PR TITLE
Improve prompt dialog behavior and version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Pinokio",
   "private": true,
-  "version": "3.41.1",
+  "version": "3.41.2",
   "homepage": "https://pinokio.co",
   "description": "pinokio",
   "main": "main.js",

--- a/prompt.html
+++ b/prompt.html
@@ -2,29 +2,38 @@
 <head>
 <style>body {font-family: sans-serif;} button {float:right; margin-left: 10px;} label { display: block; margin-bottom: 5px; width: 100%; } input {margin-bottom: 10px; padding: 5px; width: 100%; display:block;}</style>
 <script>
-document.addEventListener("DOMContentLoaded" () => {
-  document.querySelector("#cancel").addEventListener("click", (e) => {
-    debugger
-    e.preventDefault()
-    e.stopPropagation()
-    window.close()
-  })
-  document.querySelector("form").addEventListener("submit", (e) => {
-    e.preventDefault()
-    e.stopPropagation()
-    debugger
-    window.electronAPI.send('prompt-response', document.querySelector("#val").value)
-    window.close()
-  })
-})
+document.addEventListener("DOMContentLoaded", () => {
+  const val = document.getElementById("val");
+  const cancel = document.getElementById("cancel");
+  const form = document.querySelector("form");
+
+  cancel.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    window.close();
+  });
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    window.electronAPI.send("prompt-response", val.value);
+    window.close();
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      window.close();
+    }
+  });
+});
 </script>
 </head>
 <body>
 <form>
   <label for="val">${arg.title}</label>
   <input id="val" value="${arg.val}" autofocus />
-  <button id='ok'>OK</button>
-  <button id='cancel'>Cancel</button>
+  <button id="ok" type="submit">OK</button>
+  <button id="cancel" type="button">Cancel</button>
 </form>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix prompt dialog event handling and remove stray debugger
- support ESC key, cancel button type, and submit button for better UX
- bump version to 3.41.2

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bfa3c6cdac83328c55096aaf8c35b7