### PR TITLE
fix: support string-based appDir in monkeypatched yarn

### DIFF
--- a/temp/yarn.js
+++ b/temp/yarn.js
@@ -10,7 +10,7 @@ const electronRebuild = require("@electron/rebuild");
 const searchModule = require("@electron/rebuild/lib/src/search-module");
 async function installOrRebuild(config, paths, options, forceInstall = false) {
 console.log("install or rebuild", { config, options });
-    const { appDir, projectDir } = paths;
+    const { appDir, projectDir } = typeof paths === "string" ? { appDir: paths } : paths;
     let isDependenciesInstalled = false;
     for (const fileOrDir of ["node_modules", ".pnp.js"]) {
         if (await (0, fs_extra_1.pathExists)(path.join(projectDir ?? appDir, fileOrDir)) ||


### PR DESCRIPTION
## Summary
- support string-based `appDir` when monkeypatched `installOrRebuild` is invoked by older builders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run postinstall2`


------
https://chatgpt.com/codex/tasks/task_e_68c02cc456888332a2a3a323deffde69